### PR TITLE
Add response headers to error object if they exist

### DIFF
--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -33,7 +33,11 @@ var _getErrorObject = function(defaultMessage, err) {
   var errorObject;
   if (typeof err.error === 'object' && typeof err.error.message === 'string') {
     // Web API Error format
-    errorObject = new WebApiError(err.error.message, err.error.status);
+    errorObject = new WebApiError(
+      err.error.message,
+      err.error.status,
+      err.error.response && err.error.response.headers
+    );
   } else if (typeof err.error === 'string') {
     // Authorization Error format
     /* jshint ignore:start */

--- a/src/webapi-error.js
+++ b/src/webapi-error.js
@@ -1,9 +1,10 @@
 'use strict';
 
-function WebapiError(message, statusCode) {
+function WebapiError(message, statusCode, headers) {
   this.name = 'WebapiError';
   this.message = message || '';
   this.statusCode = statusCode;
+  this.headers = headers;
 }
 
 WebapiError.prototype = Error.prototype;


### PR DESCRIPTION
Allows consumers to utilize the `retry-after` header (should they be rate limited)